### PR TITLE
Use return values instead of out parameters

### DIFF
--- a/lib/include/lattice.hpp
+++ b/lib/include/lattice.hpp
@@ -61,9 +61,8 @@ public:
   void thermalize();
   void getNextConfig();
   
-  void computePath(const vector<vector<int> >& path, Matrix3cd& out);
-  void computeLine(const int start[4], const int finish[4],
-		   Matrix3cd& out);
+  Matrix3cd computePath(const vector<vector<int> >& path);
+  Matrix3cd computeLine(const int start[4], const int finish[4]);
   double computeWilsonLoop(const int corner1[4], const int corner2[4],
 			   const int nSmears = 0);
   double computeWilsonLoop(const int corner[4], const int r, const int t,
@@ -83,12 +82,12 @@ public:
   double computeMeanLink();
 
   double (Lattice::*computeLocalAction)(const int link[5]);
-  void (Lattice::*computeStaples)(const int link[5], Matrix3cd& out);
-  void makeRandomSu3(Matrix3cd& out);
-  void makeHeatbathSu2(Matrix2cd& out, double coefficients[4],
+  Matrix3cd (Lattice::*computeStaples)(const int link[5]);
+  Matrix3cd makeRandomSu3();
+  Matrix2cd makeHeatbathSu2(double coefficients[4],
 		       const double weighting);
 
-  void computeQ(const int link[5], Matrix3cd& out);
+  Matrix3cd computeQ(const int link[5]);
   void smearLinks(const int time, const int nSmears);
 
   SparseMatrix<complex<double> > computeDiracMatrix(const double mass,
@@ -106,9 +105,9 @@ protected:
   double computeLocalWilsonAction(const int link[5]);
   double computeLocalRectangleAction(const int link[5]);
   double computeLocalTwistedRectangleAction(const int link[5]);
-  void computeWilsonStaples(const int link[5], Matrix3cd& out);
-  void computeRectangleStaples(const int link[5], Matrix3cd& out);
-  void computeTwistedRectangleStaples(const int link[5], Matrix3cd& out);
+  Matrix3cd computeWilsonStaples(const int link[5]);
+  Matrix3cd computeRectangleStaples(const int link[5]);
+  Matrix3cd computeTwistedRectangleStaples(const int link[5]);
   void (Lattice::*updateFunction_)(const int link[5]);
   GaugeField links_;
   Sub4Field randSu3s_;

--- a/lib/include/pyQCD_utils.hpp
+++ b/lib/include/pyQCD_utils.hpp
@@ -39,12 +39,12 @@ namespace pyQCD
   int sgn(const int x);
   void getLinkIndices(int n, int link[5]);
 
-  void createSu2(Matrix2cd& out, const double coefficients[4]);
-  void embedSu2(const Matrix2cd& Su2Matrix, Matrix3cd& Su3Matrix,
+  Matrix2cd createSu2(const double coefficients[4]);
+  Matrix3cd embedSu2(const Matrix2cd& Su2Matrix,
 		const int index);
-  void extractSubMatrix(const Matrix3cd& su3Matrix, Matrix2cd& subMatrix,
+  Matrix2cd extractSubMatrix(const Matrix3cd& su3Matrix,
 			const int index);
-  void extractSu2(const Matrix3cd& su3Matrix, Matrix2cd& su2Matrix,
+  Matrix2cd extractSu2(const Matrix3cd& su3Matrix,
 		  double coefficients[4], const int index);  
 }
 

--- a/lib/src/pyQCD_utils.cpp
+++ b/lib/src/pyQCD_utils.cpp
@@ -98,18 +98,20 @@ namespace pyQCD
 
 
 
-  void createSu2(Matrix2cd& out, const double coefficients[4])
+  Matrix2cd createSu2(const double coefficients[4])
   {
-    out = coefficients[0] * sigmas[0];
+    Matrix2cd out = coefficients[0] * sigmas[0];
     for (int j = 1; j < 4; ++j)
       out += i * coefficients[j] * sigmas[j];
+    return out;
   }
 
 
 
-  void embedSu2(const Matrix2cd& Su2Matrix, Matrix3cd& Su3Matrix,
+  Matrix3cd embedSu2(const Matrix2cd& Su2Matrix,
 		const int index)
   {
+    Matrix3cd Su3Matrix;
     if (index == 0) {
       Su3Matrix(0, 0) = 1.0;
       Su3Matrix(0, 1) = 0.0;
@@ -143,13 +145,15 @@ namespace pyQCD
       Su3Matrix(2, 1) = 0.0;
       Su3Matrix(2, 2) = 1.0;
     }
+    return Su3Matrix;
   }
 
 
 
-  void extractSubMatrix(const Matrix3cd& su3Matrix, Matrix2cd& subMatrix,
+  Matrix2cd extractSubMatrix(const Matrix3cd& su3Matrix,
 			const int index)
   {
+    Matrix2cd subMatrix;
     if (index == 0) {
       subMatrix(0, 0) = su3Matrix(1, 1);
       subMatrix(0, 1) = su3Matrix(1, 2);
@@ -168,15 +172,15 @@ namespace pyQCD
       subMatrix(1, 0) = su3Matrix(1, 0);
       subMatrix(1, 1) = su3Matrix(1, 1);
     }
+    return subMatrix;
   }
 
 
 
-  void extractSu2(const Matrix3cd& su3Matrix, Matrix2cd& su2Matrix,
+  Matrix2cd extractSu2(const Matrix3cd& su3Matrix,
 		  double coefficients[4], const int index)
   {
-    Matrix2cd subMatrix;
-    extractSubMatrix(su3Matrix, subMatrix, index);
+    Matrix2cd subMatrix = extractSubMatrix(su3Matrix, index);
     
     coefficients[0] = subMatrix(0, 0).real() + subMatrix(1, 1).real();
     coefficients[1] = subMatrix(0, 1).imag() + subMatrix(1, 0).imag();
@@ -188,7 +192,6 @@ namespace pyQCD
 			    pow(coefficients[2], 2) +
 			    pow(coefficients[3], 2));
 
-    createSu2(su2Matrix, coefficients);
-    su2Matrix /= magnitude;
+    return createSu2(coefficients) / magnitude;
   }
 }


### PR DESCRIPTION
Using normal return values instead of out parameters makes functions
simpler and more natural to use. Due to return value optimization (RVO)
normal return values also shouldn't be any less efficient than out
parameters.

The out parameter might even need a default constructed object that can
otherwise often be avoided:

```
Matrix3cd tmp;
 func(tmp);
```

When func() simply returns the matrix there is no need to first
construct an empty tmp object:

```
 Matrix3cd tmp = func();
```

This way performance can even increase.

The change is mostly about clearer function interfaces though, so reject it if you feel it makes things less readable.

In some functions it also uses several temporary variables instead of a single one since reusing a old variable with `tmpValue = fun()` always _does_ require an actual assignment while creating a new variable like `Matrix3cd tmp2 = fun()` can directly reuse the returned value.
